### PR TITLE
Update Home Assistant Polymer version and source link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PWA = Progressive Web App
 [:link:](https://www.cloudstitch.com) | Cloudstitch | `1.5.0` | |
 [:link:](https://customelements.io) | CustomElements | `1.1.3` | | [Source](https://github.com/customelements/www)
 [:link:](http://www.ea.com) | Electronic Arts | `1.6.0` | |
-[:link:](https://home-assistant.io/demo) | Home Assistant | `1.6.0` | | [Source](https://github.com/home-assistant/home-assistant)
+[:link:](https://home-assistant.io/demo) | Home Assistant | `1.6.1` | | [Source](https://github.com/home-assistant/home-assistant-polymer)
 [:link:](https://new-console.ng.bluemix.net) | IBM Bluemix new console | `1.0.0` | |
 [:link:](https://apps.kano.me) | Kano | `1.6.0` | :heavy_check_mark: |
 [:link:](https://kongax.konga.com) | Konga EZ | `1.5.0` | :heavy_check_mark: |


### PR DESCRIPTION
Home Assistant has upgraded to 1.6.1. Also I think it is nicer to link directly to our polymer app repo.
