### PR TITLE
Add awesome_bot to check links automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+install:
+  - gem install awesome_bot
+
+script:
+  - awesome_bot *.md --skip-save-results --allow-redirect --allow-timeout --set-timeout 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ install:
   - gem install awesome_bot
 
 script:
-  - awesome_bot *.md --skip-save-results --allow-redirect --allow-timeout --set-timeout 10
+  - awesome_bot README.md --allow-redirect --allow-timeout --set-timeout 10 --skip-save-results


### PR DESCRIPTION
Bot: https://github.com/dkhamsing/awesome_bot

There are couple of dead links and duplicates:

```
> Links 
  1. [L071] 404 https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tensorboard  
  2. [L085]  https://braid.io Failed to open TCP connection to braid.io:443 (getaddrinfo: No address associated with hostname) 
  3. [L124]  https://meatscope.camera Failed to open TCP connection to meatscope.camera:443 (getaddrinfo: Temporary failure in name resolution) 
  4. [L135]  https://snapdrop.net SSL_connect returned=1 errno=0 state=error: certificate verify failed 
  5. [L136] 502 https://ww8.herokuapp.com  
> Dupes 
  1. [L17] https://developers.google.com/web/progressive-web-apps/
  2. [L36] https://santatracker.google.com
  3. [L36] https://github.com/google/santa-tracker-web
```

Probably those should be fixed/removed from the repo.

PS. thanks for the nice repo, I added the link to it in https://github.com/limonte/awesome-polymer2