### PR TITLE
Update the Vaadin expense-manager link

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Sorted alphabetically
 | [![University of Queensland, Australia - UQ Library](https://www.google.com/s2/favicons?domain=https://www.library.uq.edu.au)](https://www.library.uq.edu.au) | University of Queensland, Australia - UQ Library | `1.9` |  |  |
 | [![USA Today](https://www.google.com/s2/favicons?domain=https://www.usatoday.com)](https://www.usatoday.com) | USA Today | `1.8` | | |
 | [![Vaadin Elements](https://www.google.com/s2/favicons?domain=https://vaadin.com/elements)](https://vaadin.com/elements) | Vaadin Elements | `2.3` | | [Source](https://github.com/vaadin) |
-| [![Vaadin Expense Manager](https://www.google.com/s2/favicons?domain=https://demo.vaadin.com/expense-manager/)](https://demo.vaadin.com/expense-manager/) | Vaadin Expense Manager | `2.1` | ✅ | [Source](https://github.com/vaadin/expense-manager-demo) |
+| [![Vaadin Expense Manager](https://www.google.com/s2/favicons?domain=https://expensemanager.demo.vaadin.com/)](https://expensemanager.demo.vaadin.com/) | Vaadin Expense Manager | `2.5` | ✅ | [Source](https://github.com/vaadin/expense-manager-demo) |
 | [![Victoria's Secret](https://www.google.com/s2/favicons?domain=https://www.victoriassecret.com)](https://www.victoriassecret.com) | Victoria's Secret | `1.5` | | |
 | [![Zeplin](https://www.google.com/s2/favicons?domain=https://zeplin.io)](https://zeplin.io) | Zeplin | `1.9` | | |
 | [![Zeppidy](https://www.google.com/s2/favicons?domain=https://zeppidy.com)](https://zeppidy.com) | Zeppidy | `1.8` | | |


### PR DESCRIPTION
We have deployed a new version recently, this link is the correct one.
The old version still exists but should not be mentioned anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/abdonrd/polymerprojects/47)
<!-- Reviewable:end -->
